### PR TITLE
Add course material in a maintainable way, include more file extensions, and set up an example participant blog

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ baseurl: ""
 url: "http://ascendproject.org"
 homeurl: "/about/"
 github: "http://github.com/mozilla/ascendproject"
+markdown_ext: "markdown,mkdown,mkdn,mkd,md"
 
 # Build settings
 markdown: kramdown

--- a/course_materials/daily_agendas/_posts/2014-09-08-day-one-agenda.md
+++ b/course_materials/daily_agendas/_posts/2014-09-08-day-one-agenda.md
@@ -1,3 +1,9 @@
+---
+layout: post
+title:  "Day One Agenda"
+date:   2014-09-08
+---
+
 Agenda
 
 9-9:30 am :  Breakfast & computer sign out

--- a/course_materials/daily_agendas/_posts/2014-09-09-day-two-agenda.md
+++ b/course_materials/daily_agendas/_posts/2014-09-09-day-two-agenda.md
@@ -1,3 +1,9 @@
+---
+layout: post
+title:  "Day Two Agenda"
+date:   2014-09-09
+---
+
 Agenda
 
 9-9:30 am :  Breakfast & computer sign out
@@ -16,6 +22,6 @@ LUNCH
 * Moar terminal/command line
 ** Man pages
 ** flags
-** --help 
+** --help
 * Set up multiple Firefox (Nightly, Aurora, Beta, Release)
 * Checkout

--- a/course_materials/daily_agendas/_posts/2014-09-10-day-three-agenda.md
+++ b/course_materials/daily_agendas/_posts/2014-09-10-day-three-agenda.md
@@ -1,3 +1,9 @@
+---
+layout: post
+title:  "Day Three Agenda"
+date:   2014-09-10
+---
+
 Agenda
 
 9-9:30 am :  Breakfast & computer sign out
@@ -16,6 +22,6 @@ LUNCH
 * Moar terminal/command line
 ** Man pages
 ** flags
-** --help 
+** --help
 * Set up multiple Firefox (Nightly, Aurora, Beta, Release)
 * Checkout

--- a/course_materials/daily_agendas/_posts/2014-09-11-day-four-agenda.md
+++ b/course_materials/daily_agendas/_posts/2014-09-11-day-four-agenda.md
@@ -1,10 +1,16 @@
+---
+layout: post
+title:  "Day Four Agenda"
+date:   2014-09-11
+---
+
 Agenda
 
 9-9:30 am :  Breakfast & computer sign out
 
 * Checkin
 * Short motivational video
-* Tip of the day 
+* Tip of the day
 * Account Creation:
 ** mozillians.org
 ** badges.mozilla.org
@@ -17,5 +23,5 @@ LUNCH
 * Set up multiple Firefoxes (Nightly, Aurora, Beta, Release)
 * Git review
 * first_day folder pull requests to ascend repo
-** Markdown investigation for styling 
+** Markdown investigation for styling
 * Checkout

--- a/course_materials/daily_agendas/_posts/2014-09-12-day-five-agenda.md
+++ b/course_materials/daily_agendas/_posts/2014-09-12-day-five-agenda.md
@@ -1,19 +1,25 @@
+---
+layout: post
+title:  "Day Five Agenda"
+date:   2014-09-12
+---
+
 Agenda
 
 9-9:30 am :  Breakfast & computer sign out
 
 * Checkin
-* Tip of the day 
+* Tip of the day
 * If you didn't yet, make sure you claim your Nightly User Badge:
 ** https://badges.mozilla.org/en-US/badges/claim/vpvacp
-* More Command Line/Terminal review & new stuff 
+* More Command Line/Terminal review & new stuff
 ** review ls, cd, mkdir, touch, rm, mv, cat
 ** how to help yourself - man (cmd line), help (within a program)
 ** take a tour of your bashrc & setup alias for sublime editing (install subl)
 *** https://www.sublimetext.com/docs/3/osx_command_line.html
 ** set sublime as editor in gitconfig [git config core.editor subl]
 
-* Maker Party!!!  
+* Maker Party!!!
 ** All the tools are at https://webmaker.org/tools
 * Group Exercise: Go learn a Web Literacy skill & bring back something to teach
 ** https://webmaker.org/resources/literacy/weblit-Navigation
@@ -34,4 +40,3 @@ in Ascend, use one of the tools:
 * pull requests for new blog posts
 * Checkout (4pm) - early (4pm) for social hour with PDX office
 * Weekly stipend dispersal
-

--- a/course_materials/daily_agendas/index.html
+++ b/course_materials/daily_agendas/index.html
@@ -1,0 +1,21 @@
+---
+layout: blogs
+title: "Daily Agendas"
+---
+
+<h1>Daily Agendas</h1>
+<div>
+  <ul class="posts">
+    {% for post in site.posts %}
+      {% for cat in post.categories %}
+        {% if cat == 'daily_agendas' %}
+          <h1><a href="{{ post.url }}">{{ post.title }}</a></h1>
+          <span>{{ post.date | date_to_string }}</span> &raquo;
+
+          {{ post.content }}
+
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  </ul>
+</div>

--- a/course_materials/index.html
+++ b/course_materials/index.html
@@ -1,0 +1,44 @@
+---
+layout: blogs
+title: "Course Materials"
+---
+<h1>Course Materials</h1>
+
+<h2><a href="./policies/index.html">General Policies</a></h2>
+<div>
+  <ul class="posts">
+    {% for post in site.posts %}
+      {% for cat in post.categories %}
+        {% if cat == 'policies' %}
+          <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  </ul>
+</div>
+
+<h2><a href="./daily_agendas/index.html">Daily Agendas</a></h2>
+<div>
+  <ul class="posts">
+    {% for post in site.posts %}
+      {% for cat in post.categories %}
+        {% if cat == 'daily_agendas' %}
+          <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  </ul>
+</div>
+
+<h2><a href="./weekly_overviews/index.html">Weekly Overviews</a></h2>
+<div>
+  <ul class="posts">
+    {% for post in site.posts %}
+      {% for cat in post.categories %}
+        {% if cat == 'weekly_overviews' %}
+          <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  </ul>
+</div>

--- a/course_materials/policies/_posts/2014-09-08-attendence-policy.md
+++ b/course_materials/policies/_posts/2014-09-08-attendence-policy.md
@@ -1,32 +1,35 @@
-Attendance Policy
-=================
-
+---
+layout: post
+title:  "Attendence Policy"
+date:   2014-09-08
+permalink: attendence_policy
+---
 
 Excellent attendance is an expectation of all Ascend Project participants
 and is required in order to be gifted the laptop that participants use
-during the the program at it's completion. 
+during the the program at it's completion.
 
-Daily attendance over the 6 weeks of the program is the key to building 
-a community presence and connecting with mentors in order to complete 
+Daily attendance over the 6 weeks of the program is the key to building
+a community presence and connecting with mentors in order to complete
 technical contributions that build participants' portfolios, providing them
 with tangible outcomes that can assist in creating future opportunities.
 
 There is an honorarium for each full day of attendance, which is defined as:
 
 	A full day of attendance requires being at the Mozilla Portland office
-	9am - 5pm each day, to be in the classroom area, and to participate 
+	9am - 5pm each day, to be in the classroom area, and to participate
 	fully in the daily material as well as being a respectful and supportive
 	member in your cohort in order to build a solid team.
 
 Attendance will be recorded between 9am-9:30am every morning as computers
-are signed out to each person for the day and then again at 5pm when the 
-computers are returned. If someone is absent, misses sign in/out, is 
-disruptive in class to the point of being asked to leave, or doesn't 
+are signed out to each person for the day and then again at 5pm when the
+computers are returned. If someone is absent, misses sign in/out, is
+disruptive in class to the point of being asked to leave, or doesn't
 participate in the day's work there will be no honorarium paid for that day.
 
 To complete the course with full participation, resulting in the laptop being
 given to the participant, there must be no unscheduled absences, no more than 10
-days of absence overall, and any emergency absences/lateness must follow 
+days of absence overall, and any emergency absences/lateness must follow
 the established process.
 
 A scheduled absence must:
@@ -35,7 +38,7 @@ A scheduled absence must:
 * before 5pm end of class the day before the absence occurs
 * have confirmation from course leader in email to the participant with the
 adjustment to the honorarium based on the following:
-** no penalty for 1/4 day or less absence when needed for appointments with care 
+** no penalty for 1/4 day or less absence when needed for appointments with care
 providers or other wellness needs (includes commute time)
 ** 1/2 day absence = 1/2 daily honorarium
 ** more than 1/2 day absence = no honorarium
@@ -51,29 +54,29 @@ PHONE NUMBER #2 ____________________________
 * The honorarium will be adjusted according to the above schedule
 * Emergency/unexpected absence for more than 1/2 the day will result in no honorarium that day
 
-As much as possible, these should be minimal and pre-arranged 
-before the course begins.  Any absences during the course that are unscheduled 
+As much as possible, these should be minimal and pre-arranged
+before the course begins.  Any absences during the course that are unscheduled
 and/or result in missing class time will result in no honorarium for that day.
 
 Any extra-curricular activities that take place outside of the 9am-5pm window
-are not part of this attendance policy, they are optional, and do not 
+are not part of this attendance policy, they are optional, and do not
 impact participant honorariums.
 
 
 Acknowledgment of for the Attendance Policy
 ===========================================
 
-I have read and been informed about the content, requirements, and 
-expectations of the attendance policy for Ascend Project participants. 
-I have received a copy of the policy and agree to abide by the policy 
-guidelines as a condition of my participation and my ability to receive 
+I have read and been informed about the content, requirements, and
+expectations of the attendance policy for Ascend Project participants.
+I have received a copy of the policy and agree to abide by the policy
+guidelines as a condition of my participation and my ability to receive
 daily honorariums for said attendance as well as the laptop gifted
 at the end of the program on ____________________________.
 
-I understand that if I have questions, at any time, regarding the 
+I understand that if I have questions, at any time, regarding the
 attendance policy, I will consult with the project leaders.
 
-Please read the policy carefully to ensure that you understand the 
+Please read the policy carefully to ensure that you understand the
 policy before signing this document.
 
 Signature: _______________________________________

--- a/course_materials/policies/_posts/2014-09-08-class-agreements.md
+++ b/course_materials/policies/_posts/2014-09-08-class-agreements.md
@@ -1,5 +1,9 @@
-Class Agreements
-================
+---
+layout: post
+title:  "Class Agreements"
+date:   2014-09-08
+permalink: class_agreements
+---
 
 ### General Agreements:
 

--- a/course_materials/policies/_posts/2014-09-08-daily-schedule.md
+++ b/course_materials/policies/_posts/2014-09-08-daily-schedule.md
@@ -1,5 +1,9 @@
-Daily Schedule
-==============
+---
+layout: post
+title:  "Daily Schedule"
+date:   2014-09-08
+permalink: daily_schedule
+---
 
 9am - 9:30am: Breakfast
 
@@ -30,5 +34,3 @@ Two kinds of badges:
 
 * Created by Ascend leader-mentors to mark a specific skill
 * Created by participants to mark breakthroughs, creating a path for others to follow you
-
-

--- a/course_materials/policies/_posts/2014-09-08-extra-curricular.md
+++ b/course_materials/policies/_posts/2014-09-08-extra-curricular.md
@@ -1,5 +1,9 @@
-Extra Curricular
-================
+---
+layout: post
+title:  "Extra Curricular"
+date:   2014-09-08
+permalink: extra_curricular
+---
 
 * Family night meet n greet
 * Hack n Splode (for women only?)

--- a/course_materials/policies/index.html
+++ b/course_materials/policies/index.html
@@ -1,0 +1,21 @@
+---
+layout: blogs
+title: "General Policies"
+---
+
+<h1>General Policies</h1>
+<div>
+  <ul class="posts">
+    {% for post in site.posts %}
+      {% for cat in post.categories %}
+        {% if cat == 'policies' %}
+          <h1><a href="{{ post.url }}">{{ post.title }}</a></h1>
+          <span>{{ post.date | date_to_string }}</span> &raquo;
+
+          {{ post.content }}
+
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  </ul>
+</div>

--- a/course_materials/weekly_overviews/_posts/2014-09-08-week-one-overview.md.md
+++ b/course_materials/weekly_overviews/_posts/2014-09-08-week-one-overview.md.md
@@ -1,6 +1,8 @@
-Week 1
-======
-
+---
+layout: post
+title:  "Week One Overview"
+date:   2014-09-08
+---
 
 Day 1
 ------
@@ -14,7 +16,7 @@ AM:
 * Strength Finder exercise
 ** Do the quiz, get results
 
-PM: 
+PM:
 
 * Exploration our strengths
 ** Sharing strengths with group
@@ -24,7 +26,7 @@ PM:
 Day 2
 ------
 
-AM: 
+AM:
 
 * Checkin
 * Mozilla history (possibly show video)
@@ -79,4 +81,3 @@ Days 4 & 5
 ** MozMill
 ** Developer Tools
 ** Gaming/Graphics
-

--- a/course_materials/weekly_overviews/_posts/2014-09-15-week-two-overview.md.md
+++ b/course_materials/weekly_overviews/_posts/2014-09-15-week-two-overview.md.md
@@ -1,6 +1,8 @@
-Week 2
-======
-
+---
+layout: post
+title:  "Week Two Overview"
+date:   2014-09-15
+---
 
 Goals:
 ------

--- a/course_materials/weekly_overviews/_posts/2014-09-22-week-three-overview.md.md
+++ b/course_materials/weekly_overviews/_posts/2014-09-22-week-three-overview.md.md
@@ -1,8 +1,8 @@
-Week 3:
-=======
-
-
-
+---
+layout: post
+title:  "Week Three Overview"
+date:   2014-09-22
+---
 
 Goals:
 ------

--- a/course_materials/weekly_overviews/_posts/2014-09-29-week-four-overview.md.md
+++ b/course_materials/weekly_overviews/_posts/2014-09-29-week-four-overview.md.md
@@ -1,6 +1,8 @@
-Week 4:
-=======
-
+---
+layout: post
+title:  "Week Four Overview"
+date:   2014-09-29
+---
 
 * Meeting up with mentors
 * Showing up
@@ -10,4 +12,4 @@ Week 4:
 ** What could you do as 2 more contributions to Open Source (mozilla) in the next 6 months?
 * Creating & applying patches
 * Bugzilla -- ALL THE THINGS
-* 
+*

--- a/course_materials/weekly_overviews/_posts/2014-10-06-week-five-overview.md
+++ b/course_materials/weekly_overviews/_posts/2014-10-06-week-five-overview.md
@@ -1,5 +1,8 @@
-Week 5:
-=======
+---
+layout: post
+title:  "Week Five Overview"
+date:   2014-10-06
+---
 
 * Code Review
 ** Let's review each other's code

--- a/course_materials/weekly_overviews/_posts/2014-10-13-week-six-overview.md.md
+++ b/course_materials/weekly_overviews/_posts/2014-10-13-week-six-overview.md.md
@@ -1,6 +1,8 @@
-Week 6:
-=======
-
+---
+layout: post
+title:  "Week Six Overview"
+date:   2014-10-13
+---
 
 Goals:
 ------

--- a/course_materials/weekly_overviews/index.html
+++ b/course_materials/weekly_overviews/index.html
@@ -1,0 +1,21 @@
+---
+layout: blogs
+title: "Weekly Overviews"
+---
+
+<h1>Weekly Overviews</h1>
+<div>
+  <ul class="posts">
+    {% for post in site.posts %}
+      {% for cat in post.categories %}
+        {% if cat == 'weekly_overviews' %}
+          <h1><a href="{{ post.url }}">{{ post.title }}</a></h1>
+          <span>{{ post.date | date_to_string }}</span> &raquo;
+
+          {{ post.content }}
+
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  </ul>
+</div>

--- a/index.html
+++ b/index.html
@@ -16,11 +16,14 @@ title: Ascend Project - Home
   </div>
   <ul class="posts">
     {% for post in site.posts %}
-    <h1><a href="{{ post.url }}">{{ post.title }}</a></h1>
-    <span>{{ post.date | date_to_string }}</span> &raquo;
-        
-        {{ post.content }}
-      
+      {% unless post.categories contains "course_materials" %}
+
+          <h1><a href="{{ post.url }}">{{ post.title }}, {{ cat }}</a></h1>
+          <span>{{ post.date | date_to_string }}</span> &raquo;
+
+          {{ post.content }}
+
+      {% endunless %}
     {% endfor %}
   </ul>
 </div>

--- a/participants/portland/lukas/_drafts/how-to-make-participant-blogs-work.markdown
+++ b/participants/portland/lukas/_drafts/how-to-make-participant-blogs-work.markdown
@@ -1,16 +1,14 @@
 ---
 layout: post
 title:  "Test participant blog"
-date:   2014-09-12 14:23:14
 categories: lukas
-draft: true
 ---
 
 ### To make the participant blogs work:
 
 * Create a `_posts` directory in your individual participants directory.
 * Create an `index.html` file in your individual participants directory.
-* Paste [this code](https://gist.github.com/shawnacscott/87920adff230fa37a61f) in, with your first name as the category in the appropriate place.
+* Paste [this code](https://gist.github.com/shawnacscott/87920adff230fa37a61f) in, with your first name as the category in the appropriate places.
 * Every time you make a blog post, name it `YEAR-MONTH-DAY-title.markdown`, and paste this at the top of your file, filling in the appropriate info:
 
 ~~~
@@ -21,3 +19,5 @@ date:   YEAR-MONTH-DAY
 categories: your-participant-name
 ---
 ~~~
+
+* If you want to be able to work with drafts and not publish your posts immediately, create a `_drafts` directory in your individual participants directory. When you are ready to publish, move the post to the `_posts` directory.

--- a/participants/portland/lukas/_posts/2014-08-09-first-day.markdown
+++ b/participants/portland/lukas/_posts/2014-08-09-first-day.markdown
@@ -1,0 +1,23 @@
+---
+layout: post
+title:  "Test participant blog"
+date:   2014-09-12 14:23:14
+categories: lukas
+draft: true
+---
+
+### To make the participant blogs work:
+
+* Create a `_posts` directory in your individual participants directory.
+* Create an `index.html` file in your individual participants directory.
+* Paste [this code](https://gist.github.com/shawnacscott/87920adff230fa37a61f) in, with your first name as the category in the appropriate place.
+* Every time you make a blog post, name it `YEAR-MONTH-DAY-title.markdown`, and paste this at the top of your file, filling in the appropriate info:
+
+~~~
+---
+layout: post
+title:  "Title of Your Post"
+date:   YEAR-MONTH-DAY
+categories: your-participant-name
+---
+~~~

--- a/participants/portland/lukas/index.html
+++ b/participants/portland/lukas/index.html
@@ -1,0 +1,20 @@
+---
+layout: blogs
+title: Lukas' Blog
+---
+
+<div>
+  <ul class="posts">
+    {% for post in site.posts %}
+      {% for cat in post.categories %}
+        {% if cat == 'lukas' %}
+          <h1><a href="{{ post.url }}">{{ post.title }}</a></h1>
+          <span>{{ post.date | date_to_string }}</span> &raquo;
+
+          {{ post.content }}
+          <hr />
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  </ul>
+</div>

--- a/volunteer.md
+++ b/volunteer.md
@@ -19,7 +19,7 @@ Ascend is currently very much in Beta and needs a lot of help to get off the gro
 * Write an article or blog about Ascend if you are a blogger/journalist
 * Test out the curriculum pages (when ready) and submit bugs or patches with fixes
 * Design help with course materials (when ready)
-* Be a helper for July drop-in 'office hours' for potential participants who need access to computers & internet
+* Be a helper for July drop-in 'office hours' for potential participants who need access to computers & internet. Make sure to read the [class agreements](../class_agreements) beforehand.
 * Site improvements always considered
 
 ## In-Class Helpers


### PR DESCRIPTION
This pull request adds the course material in a way that will allow it to automatically aggregate in the appropriate places based on three categories: `policies`, `daily_agendas`, and `weekly_overviews`. These materials are now linked individually on the course materials page, as well as having their own category aggregates, e.g., all policies can be seen in one place. Also, policies now have prettified permalinks.

It also modifies the `_config.yml` file to allow Jekyll to interpret files with multiple markdown extensions. Previously, the site would only appropriately render files with a `.markdown` extension.

It also sets up an example blog structure under @lsblakk's participant folder that allows for posts and drafts, as well as each participant to have their blogs both aggregate into the main blog feed, as well as have an individual page that shows just their posts under `http://ascendproject.org/participants/portland/participant-name/`.
