### PR TITLE
adds link to individual blog posts on portland participants page

### DIFF
--- a/_data/portland.yml
+++ b/_data/portland.yml
@@ -8,42 +8,50 @@
   participants:
     -
       name: "Jessica Canepa"
+      blog_dir: "jessica"
       role: "participant"
       image: "jessica_canepa.jpg"
       bio: " Jessica's curiosity has taken her from Portland across the globe to remote parts of Siberia and the Russian Far East.  As a first-generation college student she studied Russian and International Affairs at Lewis & Clark College. After graduation she traveled across Russia, taught English and studied Russian Art History on a generous grant. Upon her return to her hometown she's worked and volunteered at a variety of non-profits. Her love of learning and exploring new ideas has led her to study Python and JavaScript among other programming topics. She is excited to continue to venture into the open source world with Mozilla's Ascend Project. She tweets @jmarlena_canepa."
     -
       name: "Becky Scheffler"
       role: "participant"
+      blog_dir: "becky"
       image: "rebecca_scheffler.jpg"
       bio: "Becky Scheffler: I have lived all over Oregon and finally feel like Portland may be our forever city.  I enjoy hiking, camping, crabbing and also Minecrafting with my kiddos. I am excited to jump into the Ascend program and the programming world! "
     -
       name: "J.D. West"
       role: "participant"
+      blog_dir: "JD"
       image: "jd_west.jpg"
       bio: "​Hi i'm James West, I prefer to go by J.D I am 22 years old and moved to Portland from Austin, Texas a few months ago. I create super awesome dance music on a old Gameboy in my spare time."
     -
       name: "Lisa Hewus Fresh"
       role: "participant"
+      blog_dir: "lisa"
       bio: "Lisa Hewus Fresh is a wife and mother of five who has recently (and very happily) relocated to beautiful North Portland from ridiculously hot Arizona. Lisa previously did technical support and was the chief of operations for a privately owned ISP and is now focusing on learning to program. She loves to read and collect books she intends to read someday. She also loves gardening and playing the drums."
       image: "lisa_hewus_fresh.jpg"
     -
       name: "Nina Alcaras"
       role: "participant"
+      blog_dir: "k"
       image: "nina_alcaras.jpg"
       bio: "having a good day"
     -
       name: "Carmen Cordis"
       role: "participant"
+      blog_dir: "carmen"
       bio: "Carmen Cordis is an enthusiastic wordsmith, choral singer, and lover of languages living in Portland, Oregon.  A lifelong learner, Carmen also finds inspiration in art history as a mirror of cultural development and a window through time.  As a writer and linguist, Carmen specializes in Classical Latin (12+ years of learning) and Ancient Greek (7+ years of learning).  She thoroughly enjoys translating, tracing word origins, and looking for patterns across multiple languages throughout history. Carmen also completed a B.A. program in Classics and Classical Humanities at the University of Wisconsin-Madison.  Her love of learning, asking questions, and encouraging students has driven her to pursue even more learning and teaching opportunities for personal and social enrichment. <br /><br />  Carmen has experience as an academic tutor, educator, and published author.  She has lived and worked as an animal caretaker, a member of multiple choirs, and a vegetarian.  She has participated in and assisted in leading advocacy trainings, workshops, fundraising, and community events in support of queer and trans* social justice, women’s empowerment, and communities of color.  Her work also includes advocacy focused on housing disparities, domestic violence, behavioral health, and public health. <br /> <br /> Carmen loves gaming, and has eagerly begun to learn computer coding skills (like JavaScript, HTML, CSS, and Ruby) in order to explore and create connections between programming, gaming, and teaching.  She also writes poetry and prose inspired by her Classical background.  In her writing, she expresses emotions and experiences by using words as vivid pictures.  Carmen hopes to publish more of her writings on a broad scale, and travel the world to experience more wonders.  In addition to teaching, she would love to work in a museum as a researcher or docent, as a game designer, and as a programmer.  Her favorite color is purple (yay!) and she probably drinks too much coffee!  :)"
       image: "carmen_cordis.jpg"
     -
       name: "Peri Ahmadi"
       role: "participant"
+      blog_dir: "peri"
       bio: "I'm from Houston, Texas. I enjoy sweet tea, music, games, exercise, chocolate, and lots of other stuff. There are also things I don't enjoy (I'm looking at you, mosquitoes). I'm trying to learn stuff now that I'm getting old."
-      image: 'peri_ahmadi.jpg'    
+      image: 'peri_ahmadi.jpg'
     -
       name: "Agustina Hinojosa"
       role: "participant"
+      blog_dir: "tina"
       image: "agustina_hinojosa.jpg"
       bio: "I'm on the computer about 8 hours a day, either researching cool projects or playing video games. I feel at home on a command line and use linux as my primary OS. My favorite ice cream is cookie dough and I like the movie Be Kind Rewind."
     -
@@ -51,9 +59,11 @@
       bio: "Most significant work I've done is at KPFK, Los Angeles the 2nd Pacifica radio station. A free-form non-commercial radio station where I worked in the subscriptions office but got training in their apprentice program. From there I started recording events, interviews and producing programs. Many of the topics were on health and public affairs (speaking events, politics, government corruption). <br /><br />In Oregon my interests include gardening/permaculture, off-grid-living and just about anything odd.  To a lesser extent I have volunteered and worked at KBOO, a local public radio station.  Former techno geek, 'cuz right now I can barely adjust the audio on my computer.   I did own a portable TRS-80 that printed on paper rolls using color ink pens and ran on the BASIC program.<br /><br /> If my friends read this they would say, 'You forgot to mention you ride an old bike and your car is more worn out than the bike!' I do hope to own an electric vehicle someday."
       image: "mel_reslor.jpg"
       role: "participant"
+      blog_dir: "mel"
     -
       name: "Candida Haynes;"
       role: "participant"
+      blog_dir: "candida"
       image: "candida_haynes.jpg"
       bio: "Two truths and a lie: <ol><li>I watch pro wrestling with my grandmother.</li><li>I sing like an angel and rap like a boss.</li><li>In imaginary conversations about Elon Musk, I often refer to him as Nicola Tesla by accident.</li></ol>"
     -
@@ -61,34 +71,41 @@
       image: "jennifer_cazares.jpg"
       bio: "Jennifer- better known as 'Yenni' is a vessel for social change, having dedicated the last decade to positive youth development in various arenas of the Public Health movement. Lover of the outdoors and all things living. 'Dropping knowledge and love everywhere I go.'"
       role: "participant"
+      blog_dir: "yenni"
     -
       name: "Eva Schweber"
       image: "eva_schweber.jpg"
       role: "participant"
+      blog_dir: "eva"
       bio: "I’m just your average 21st century renaissance woman. My career thus far has been anything but linear. I don’t feel constrained by implicit boundaries. I have been a web developer, dairy goat farmer, entrepreneur, public policy advisor, management consultant, crafter, facilitator, grant manager and management analyst. I see and understand the world differently than the average bear. It is this very wealth of experience that made me the tech whisperer that I am today."
     -
       name: "Virginia Thayer"
       role: "participant"
+      blog_dir: "virginia"
       image: "virginia_thayer.jpg"
       bio: "Born in Michigan and now a naturalized Portlander, Virginia is a fun-loving adventure seeker with a liberal arts degree from Portland State, currently conquering a career change from admin support to tech/programming. She'll tell you all about it at karaoke night."
     -
       name: "Amanda Houle"
       role: "participant"
+      blog_dir: "amanda"
       image: "amanda_houle.jpg"
       bio: " I remember Logo in middle school!  Oh what fun.  After one year as an engineering major in college, I decided that I wasn't super excited about the boys club (we were still teenagers) and left tech altogether.  Fast forward almost 20 years later (OMG!), after a successful yoga teaching 'career' covering Asia and Europe, I have a small daughter to role model for.  I think the US is a better place for both of us to blossom into the powerful women that we will become and back in tech is where I want to be.  Here's to hoping that those tech-related neurons in my brain will still fire!"
     -
       name: "Barbara Miller"
       role: "participant"
+      blog_dir: "barbara"
       image: "barbara_miller.jpg"
       bio: "Two truths and a lie: <ul><li>Last year as a volunteer I finished updating a non-profit's Drupal site.</li><li>This summer I've been paid to update some 2003 Visual Basic code.</li><li>I not only took this photo, I grew these wonderful daffodils.</li></ul>"
     -
       name: "David Hinojosa"
       role: "participant"
+      blog_dir: "david"
       image: "david_hinojosa.jpg"
       bio: "David is a 20 something year old who's making it up as he goes. He likes long walks on the beach, cotton candy, and cold weather."
     -
       name: "Zeus Intuivo"
       role: "participant"
+      blog_dir: "zeus"
       image: "zeus_intuivo.jpg"
       bio: "Igniting coding with a smile and cup of coffee."
     -
@@ -96,12 +113,15 @@
       image: "adam_okoye.jpg"
       bio: "Adam Okoye is a 27 year old Portland native. Having always been interested in technology he started taking apart computers in elementary school and taught himself HTML in middle school. Adam also is a flutist and studied music and German at Sarah Lawrence College. In his spare time Adam studies languages, knits, and spins yarn."
       role: "participant"
+      blog_dir: "adam"
     -
       name: "Mary Anne Thygesen"
       role: "participant"
+      blog_dir: "maryanne"
       image: "maryanne_thygesen.jpg"
       bio: "I have a hard time writing short bios. For starters, my favorite color is purple. I make most of my own clothes. I am in aurora chorus, second soprano."
     -
       name: "Sofie Adler"
       role: "participant"
+      blog_dir: "sofia"
       image: "SAdler.jpg"

--- a/participants/portland/index.html
+++ b/participants/portland/index.html
@@ -8,12 +8,14 @@ title: Bio Page for Portland Ascend Participants
 
 			{% for participant in site.data.portland.participants %}
 			<div id="userBio">
-				
-				
+
+
 				<div class="data">
-					<h1>{{ participant.name }}</h1>
+					<h1>
+						<a href="{{ participant.blog_dir }}">{{ participant.name }}</a>
+					</h1>
 					<h3>{{ participant.homebase }}</h3>
-					
+
 					{% if participant.webpage %}
 					<h4><a href="{{ participant.webpage }}">{{ participant.webpage }}</a></h4>
 					{% endif %}
@@ -25,7 +27,7 @@ title: Bio Page for Portland Ascend Participants
 					</div>
 					{% endif %}
 				</div>
-				
+
 			<div class="pic" style="display:inline">
 				{% if participant.image %}
 					<img src="/images/portland_participants/{{ participant.image }}" width="400" />
@@ -33,7 +35,7 @@ title: Bio Page for Portland Ascend Participants
 				  <img src="/images/ascend_one_color_image_placeholder.png" width="150" />
 				 {% endif %}
 			</div>
-			
+
 			<div class="bio">
 			{% if participant.bio %}
 				{{ participant.bio }}
@@ -46,7 +48,7 @@ title: Bio Page for Portland Ascend Participants
 				<div class="head"><h3>Badges(0)</h3></div>
 				<div class="boxy">
 					<p>Keep working to unlock badges!</p>
-					
+
 					{% for badge in particpant.badges %}
 					<div class="badgeCount">
 						<a href="#"><img src="img/badge.png" /></a>


### PR DESCRIPTION
at ascendproject.org/participants/portland participant names are links to each participants' blog page (provided that index.html exists. If the participant hasn't made their index.html then the link is a 404).
